### PR TITLE
FUI-426: Ensure client-side validation updates the model if enabled.

### DIFF
--- a/js/services/engine.ts
+++ b/js/services/engine.ts
@@ -904,6 +904,19 @@ export const move = (outcome: any, flowKey: string)  => {
 
         const isValid = State.isAllValid(flowKey);
         if (!isValid) {
+
+            // Update model with client-side validated component state.
+            const components = State.getComponents(flowKey);
+            if (components) {
+                for (const id in components) {
+                    const model = Model.getComponent(id, flowKey);
+                    if (model) {
+                        model.isValid = components[id].isValid;
+                        model.validationMessage = components[id].validationMessage;
+                    }
+                }
+            }
+
             render(flowKey);
 
             requestAnimationFrame(() => {
@@ -1355,4 +1368,3 @@ export const render = (flowKey: string) => {
         ReactDOM.render(React.createElement(Component.getByName(Utils.extractElement(flowKey)), { flowKey, container }), container);
     }
 };
-


### PR DESCRIPTION
The validation messages were not being shown with client-side validation enabled because the internal model was not updated with the validation state of the components.

If client-side validation is disabled, then the request is sent to the API which responds with a validation error and updates the model as part of processing the response.

With client-side validation enabled the validation error is already detected and the validation state updated, but because a request/response is not received the model was never updated with the new component state. The fix is to reflect the validation state change in the model to ensure all the components are rendered correctly.