### PR TITLE
Feature/flow 477 surface errors

### DIFF
--- a/js/services/engine.ts
+++ b/js/services/engine.ts
@@ -1179,7 +1179,12 @@ export const objectDataRequest = (
             State.setComponentError(id, null, flowKey);
 
         })
-        .fail((xhr, status, error) => {
+        .fail((xhr: any, status, error: string) => {
+
+            if (!error && xhr && xhr.responseJSON && xhr.responseJSON.message) {
+                // No useful error supplied, so grab the raw response
+                error = xhr.responseJSON.message;
+            }
 
             State.setComponentError(id, error, flowKey);
 

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -559,6 +559,26 @@ test.serial('ObjectDataRequest Fail', async (t) => {
     t.true(state.setComponentLoading.secondCall.calledWith('id', null, flowKey));
 });
 
+test.serial('ObjectDataRequest Fail extended error response', async (t) => {
+    ajax.dispatchObjectDataRequest.callsFake(() => {
+        const deferred =  $.Deferred();
+        deferred.reject({ responseJSON: { message: 'API error message returned'  } }, 'status', '');
+        return deferred;
+    });
+
+    model.getComponent.returns({
+        objectData: null,
+        objectDataRequest: {},
+    });
+
+    await t.throws(Engine.objectDataRequest('id', 'request', flowKey, 10, 'search', 'orderBy', 'orderByDirection', 1));
+
+    t.true((Engine.render as sinon.SinonStub).calledTwice);
+    t.true(state.setComponentError.calledWith('id', 'API error message returned', flowKey));
+    t.true(state.setComponentLoading.firstCall.calledWith('id', { message: '' }, flowKey));
+    t.true(state.setComponentLoading.secondCall.calledWith('id', null, flowKey));
+});
+
 test.serial('Sync', (t) => {
     ajax.invoke.callsFake(() => {
         const deferred =  $.Deferred();


### PR DESCRIPTION
If the returned error message is blank then return the raw response error if present.

Now the API error message is displayed in the Tooling when creating a swimlane group.