### PR TITLE
FLOW-2548 - Moving with the invoke type the engine has given us

### DIFF
--- a/js/services/engine.ts
+++ b/js/services/engine.ts
@@ -980,7 +980,7 @@ export const move = (outcome: any, flowKey: string)  => {
 
     const invokeRequest = Json.generateInvokeRequest(
         State.getState(flowKey),
-        'FORWARD',
+        Model.getInvokeType(flowKey),
         outcome.id,
         null,
         State.getPageComponentInputResponseRequests(flowKey),

--- a/js/services/engine.ts
+++ b/js/services/engine.ts
@@ -950,7 +950,7 @@ export const initializeSimple = (
 };
 
 /**
- * Invoke with a `FORWARD` down a specified outcome
+ * Invoke with the invoke type that the engine returned to us last (usually `FORWARD` or `RETURN`) down a specified outcome
  */
 export const move = (outcome: any, flowKey: string)  => {
 


### PR DESCRIPTION
The Subflow invoke method has a different way of dealing with a RETURN invokeType depending on whether you are in Debug_Stepthrough or not.

The upper option on line Subflow.cs:96 happens in normal execution, or when the user has seent he debug UI, and wants to continue (isContinueRequest).

The lower else option on line Subflow.cs:115 happens when the user first tries to return but is in Debug_Stepthrough, so we want to show a debug screen to them.

This lower option is first hit in a flow, then the user is presented with some debug data about the flow and is offered a "continue" button. At this point, the engine has not yet finished it's RETURN to the top most flow fully, and is expected to be told to continue returning. But the UI always sends a "FORWARD" with these Debug_Stepthrough continue buttons, and when the UI sends that, the code on line Subflow.cs:96 that happens in normal execution is not hit, and so the flow instead goes forward from the subflow map element, instead of returning from it, which leads to the subflow being invoked again and the looping behaviour reported.

So I guess there are 2 ways we could fix this, when the subflow receives a forward and it knows it's a continue request from the ui, then it executes the subflow return method as normal. The problem with this method is if the UI is really sending 'FORWARD', then maybe it actually does want to go forward, which would mean not returning from the subflow, but going back in. In that case it doesn't make sense to ignore the UI's invoke type and try to cover it over and do a 'RETURN'.

Or the UI sends the 'RETURN' invoke type that the engine expects, here I do that by using the invoke type the engine sends last, as that seemed to be what the engine expected to happen.